### PR TITLE
プロファイルで abstract要素を非必須にする

### DIFF
--- a/rtsprofile/rts_profile.py
+++ b/rtsprofile/rts_profile.py
@@ -191,7 +191,7 @@ Update date: {3}\nVersion: {4}\n'.format(self.id, self.abstract,
     @abstract.setter
     def abstract(self, abstract):
         validate_attribute(abstract, 'rts_profile.abstract',
-                           expected_type=string_types(), required=True)
+                           expected_type=string_types(), required=False)
         self._abstract = abstract
 
     @property


### PR DESCRIPTION
RTSystemEditorでxmlファイルを保存後、rtshellのrtresurrectコマンドでのファイル読み込みに失敗する。
これはrtsprofileがxmlファイルでabstruct要素を設定する必要があるが、RTSystemEditorではabstractを設定できないため、RTSystemEditorとrtshellの連携が上手くできていない。
このためabstractを設定していなくても読み込めるように変更した。