### PR TITLE
setup.pyのバージョン更新

### DIFF
--- a/rtsprofile/rts_profile.py
+++ b/rtsprofile/rts_profile.py
@@ -608,7 +608,7 @@ Update date: {3}\nVersion: {4}\n'.format(self.id, self.abstract,
     ###########################################################################
     # API functions
 
-    def find_comp_by_target(self, target):
+    def find_comp_by_target(self, target, strict=False):
         '''Finds a component using a TargetComponent or one of its subclasses.
 
         @param A @ref TargetComponent object or subclass of @ref
@@ -620,7 +620,8 @@ Update date: {3}\nVersion: {4}\n'.format(self.id, self.abstract,
         for comp in self._components:
             if comp.id == target.component_id and \
                     comp.instance_name == target.instance_name:
-                return comp
+                    if not strict or comp.path_uri == target.properties["COMPONENT_PATH_ID"]:
+                        return comp
         raise MissingComponentError
 
     def optional_data_connections(self):

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ import setuptools
 import sys
 
 
-setuptools.setup(name='rtsprofile',
-      version='4.1.1',
+setuptools.setup(name='rtsprofile-aist',
+      version='4.1.3',
       description='Library to read, manipulate and write RT system profiles \
 using the RTSProfile XML schema.',
       long_description='Library to read, manipulate and write RT system \
@@ -45,6 +45,11 @@ profiles using the RTSProfile XML schema.',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Programming Language :: Python :: 2.7',
+          'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
+          'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
           'Topic :: Software Development',
           ],
       packages=['rtsprofile'],


### PR DESCRIPTION
rtsprofileのバージョンを4.1.3に更新した。
rtsprofileは以下のプロジェクトにアップロードするため、名前を`rtsprofile`から`rtsprofile-aist`に変更した。

- https://pypi.org/manage/project/rtsprofile-aist/releases/

対応するPythonのバージョンに3.5、3.6、3.7、3.8、3.9を追加した。