### PR TITLE
COPYRIGHTファイル新設と連絡先情報の更新

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,10 @@
+
+Copyright (C) 2009-2021
+    Geoffrey Biggs
+    RT-Synthesis Research Group
+    Intelligent Systems Research Institute,
+    National Institute of Advanced Industrial Science and Technology (AIST),
+    Japan
+    All rights reserved.
+Licensed under the GNU Lesser General Public License version 3.
+http://www.gnu.org/licenses/lgpl-3.0.en.html

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(name='rtsprofile-aist',
 using the RTSProfile XML schema.',
       long_description='Library to read, manipulate and write RT system \
 profiles using the RTSProfile XML schema.',
-      author='Noriaki Ando',
+      author='Geoffrey Biggs, Noriaki Ando',
       author_email='n-ando@aist.go.jp',
       url='https://github.com/OpenRTM/rtsprofile',
       license='LGPL3',

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setuptools.setup(name='rtsprofile-aist',
 using the RTSProfile XML schema.',
       long_description='Library to read, manipulate and write RT system \
 profiles using the RTSProfile XML schema.',
-      author='Geoffrey Biggs',
-      author_email='geoffrey.biggs@aist.go.jp',
-      url='http://github.com/gbiggs/rtsprofile',
+      author='Noriaki Ando',
+      author_email='n-ando@aist.go.jp',
+      url='https://github.com/OpenRTM/rtsprofile',
       license='LGPL3',
       classifiers=[
           'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Link to #7 

- 各Pythonファイルに書かれている Copyright を新設した rtsprofile/COPYRIGHT に記載
- 今後更新年をアップデートする際は、このCOPYRIGHTファイルのみ更新する
- setup.py に記載している連絡先情報を更新した